### PR TITLE
Template new YAML mongod.conf file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,20 +83,13 @@
   with_items: mongodb_deb_packages
   when: ansible_os_family == 'Debian'
 
-- name: Enable mongo outside connections
-  lineinfile:
+- name: Install mongod configuration
+  template:
+    src: 'mongod.conf.j2'
     dest: '/etc/mongod.conf'
-    regexp: '^#?\s*bind_ip\s*='
-    line: "bind_ip=0.0.0.0"
-    state: present
-  notify: restart mongo
-
-- name: Enable mongo authentication
-  lineinfile:
-    dest: '/etc/mongod.conf'
-    regexp: '^#?\s*auth\s*='
-    line: "auth=true"
-    state: present
+    mode: '0644'
+    owner: 'root'
+    group: 'root'
   notify: restart mongo
 
 - name: Enable and start mongo service

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -1,0 +1,46 @@
+# mongod.conf
+
+# for documentation of all options, see:
+#   http://docs.mongodb.org/manual/reference/configuration-options/
+
+# where to write logging data.
+systemLog:
+  destination: file
+  logAppend: true
+  path: /var/log/mongodb/mongod.log
+
+# Where and how to store data.
+storage:
+  dbPath: /var/lib/mongo
+  journal:
+    enabled: true
+#  engine:
+#  mmapv1:
+#  wiredTiger:
+
+# how the process runs
+processManagement:
+  fork: true  # fork and run in background
+  pidFilePath: /var/run/mongodb/mongod.pid  # location of pidfile
+
+# network interfaces
+net:
+  port: 27017
+  bindIp: 0.0.0.0 # listen on all interfaces
+
+
+# Enable security
+security:
+  authorization: enabled
+
+#operationProfiling:
+
+#replication:
+
+#sharding:
+
+## Enterprise-Only Options
+
+#auditLog:
+
+#snmp:


### PR DESCRIPTION
As of `mongo-org-server-3.0.7`, the RPM and DEB packages default to the newer YAML config format (https://jira.mongodb.org/browse/SERVER-14750).  The existing playbook relies on the old-style config file format and will not work with the latest mongo packaging.  Additionally, using `lineinfile` to modify a YAML file is slightly painful.  Instead, this pull-request templates the `mongod.conf` file.
